### PR TITLE
Added Spire Armor Trim Smithing Template to End City Loot.

### DIFF
--- a/data/minecraft/loot_table/chests/end_city_treasure.json
+++ b/data/minecraft/loot_table/chests/end_city_treasure.json
@@ -9,6 +9,21 @@
 				{
 					"type": "minecraft:item",
 					"weight": 1,
+					"name": "minecraft:spire_armor_trim_smithing_template"
+				},
+				{
+					"type": "minecraft:empty",
+					"weight": 14
+				}
+			]
+		},
+		{
+			"rolls": 1,
+			"entries":
+			[
+				{
+					"type": "minecraft:item",
+					"weight": 1,
 					"name": "minecraft:end_crystal"
 				},
 				{


### PR DESCRIPTION
Added additional Loot Pool for Spire Armor Trim based on the vanilla spawning pool and weight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a rare chance to find the Spire Armor Trim Smithing Template in End City Treasure chests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->